### PR TITLE
remove unused dependency, update peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,12 +21,11 @@
   },
   "homepage": "https://github.com/idyll-lang/idyll-regl-component#readme",
   "dependencies": {
-    "idyll-component": "^1.0.5",
     "multi-regl": "^1.1.1"
   },
   "peerDependencies": {
-    "react": "^15.4.2",
-    "react-dom": "^15.4.2"
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",


### PR DESCRIPTION
This should fix warnings on install that @carlcorder flagged in gitter:

```
carlc@thinkpad ~/my-idylll-project $ npm install --save idyll-regl-component@latest
npm WARN idyll-regl-component@1.0.5 requires a peer of react@^15.4.2 but none is installed. You must install peer dependencies yourself.
npm WARN idyll-regl-component@1.0.5 requires a peer of react-dom@^15.4.2 but none is installed. You must install peer dependencies yourself.
npm WARN idyll-component@1.2.2 requires a peer of react@^15.5.4 but none is installed. You must install peer dependencies yourself.
npm WARN idyll-component@1.2.2 requires a peer of react-dom@^15.5.4 but none is installed. You must install peer dependencies yourself.
```